### PR TITLE
Update table selector

### DIFF
--- a/content-script.js
+++ b/content-script.js
@@ -37,7 +37,7 @@ function getDataFromTableRow(row) {
 }
 
 function getQueryResultsFromTable() {
-  const bqResultTable = document.getElementsByTagName("bq-results-table")[0];
+  const bqResultTable = document.getElementsByTagName("bq-nestable-table")[0];
   const table = bqResultTable.getElementsByTagName("table")[0];
 
   const thead = table.getElementsByTagName("thead")[0];


### PR DESCRIPTION
## Why
Currently, BigQuery's result table is written in the following code.
So the specified selector would not work.

```html
<table _ngcontent-uwf-c865="" mat-table="" class="mat-table cdk-table bq-nestable-table cfc-border-primary cdk-table-fixed-layout mat-table-fixed-layout" role="table">
```

## What
I updated the table selector.