### PR TITLE
Specify z-index to display the button over the content

### DIFF
--- a/content-script.js
+++ b/content-script.js
@@ -137,6 +137,7 @@ copyButton.style.cssText = `
   outline: none;
   min-width: 60px;
   border-style: none;
+  z-index: 1;
 `;
 
 copyButton.addEventListener("click", () => {


### PR DESCRIPTION
## Why
The copy button is often partially hidden :(

<img width="659" alt="image" src="https://user-images.githubusercontent.com/8983747/159647103-e65daaf9-5b85-4bca-b68e-a048237d4101.png">


## What
I specified z-index to display the button over the content.
It is an ad-hoc approach, but it is better than not being able to press the button.